### PR TITLE
Add a sudo file allowing the ccs user to control ccs services

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,6 +22,15 @@ class ccs_software::service {
       -> service { $svc:
         enable => true,
       }
+
+      $epp_sudo_vars = {
+        service => $svc,
+        user    => $ccs_software::user,
+      }
+
+      sudo::conf { "ccs-service-${svc}":
+        content => epp("${module_name}/sudo/ccs.sudo.epp", $epp_sudo_vars),
+      }
     }
   }
 }

--- a/templates/sudo/ccs.sudo.epp
+++ b/templates/sudo/ccs.sudo.epp
@@ -1,0 +1,7 @@
+<%- | String $service, String $user | -%>
+Cmnd_Alias CCS_<%= upcase($service) %> = \
+<%= join(['start', 'stop', 'restart', 'status'].map |$task| {
+  "/usr/bin/systemctl ${task} ${service}, \\\n/usr/bin/systemctl ${task} ${service}.service"
+}, ", \\\n") %>
+
+<%= $user %> ALL= NOPASSWD: CCS_<%= upcase($service) %>


### PR DESCRIPTION
This replaces /etc/cron.hourly/ccs-sudoers-services from lsst-itconf.
Any CCS services not managed by Puppet will not get automatic sudo rules.