### PR TITLE
set org.hibernate.level=WARNING

### DIFF
--- a/templates/config/ccsGlobal.properties.epp
+++ b/templates/config/ccsGlobal.properties.epp
@@ -1,5 +1,6 @@
 <%- | Array[String] $global_properties = [] | -%>
 # This file is managed by Puppet; changes may be overwritten
+org.hibernate.level=WARNING
 org.lsst.ccs.level=INFO
 org.lsst.ccs.logdir=/var/log/ccs
 <% $global_properties.each |$line| { -%>


### PR DESCRIPTION
in order to get rid of super verbose output to the local database log
files.