### PR TITLE
Produce alert emails when a ccs systemd service fails

### DIFF
--- a/files/service/systemd-email
+++ b/files/service/systemd-email
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+to=$1
+service=$2
+
+mail -Ssendwait -s "systemd status change: $service" $to <<EOF
+
+Status of service $service:
+
+$(systemctl status "$service")
+
+EOF
+
+exit 0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,10 @@
 # @param adm_group
 #   Name of the admin role group
 #
+# @param service_email
+#   String giving email address (or comma separated addresses) to
+#   receive change of service status emails from systemd.
+#
 # @param pkglist_repo_url
 #   URL of the git repo to use for `install.py` package lists by default.  This
 #   may be overriden in a `installations` hash with the `repo_url` key.
@@ -88,6 +92,7 @@ class ccs_software(
   String                      $group            = 'ccs',
   String                      $adm_user         = 'ccsadm',
   String                      $adm_group        = 'ccsadm',
+  String                      $service_email    = 'root@localhost',
   Stdlib::HTTPUrl             $pkglist_repo_url = 'https://github.com/lsst-camera-dh/dev-package-lists',
   Stdlib::HTTPUrl             $release_repo_url = 'https://github.com/lsst-it/release',
   String                      $release_repo_ref = 'IT-2233/working',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -41,4 +41,31 @@ class ccs_software::service {
       }
     }
   }
+
+  $email_helper = 'systemd-email'
+
+  file { "/usr/local/libexec/${email_helper}":
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => "puppet:///modules/${module_name}/service/${email_helper}",
+  }
+
+  $email_config = 'systemd-email'
+  $email_service = 'status-email-user@.service'
+  $envfile = "${ccs_software::etc_path}/${email_config}"
+
+  systemd::unit_file { $email_service:
+    content => epp("${module_name}/service/${email_service}.epp", {'envfile' => $envfile})
+  }
+
+  file { $envfile:
+    ensure  => file,
+    owner   => $ccs_sofware::adm_user,
+    group   => $ccs_sofware::adm_group,
+    mode    => '0644',
+    content => epp("${module_name}/service/${email_config}", {'email' => $ccs_software::service_email}),
+  }
+
 }

--- a/templates/service/ccs.service.epp
+++ b/templates/service/ccs.service.epp
@@ -8,6 +8,7 @@
 Description=<%= $desc %>
 Wants=network-online.target
 After=network-online.target
+OnFailure=status-email-user@%n.service
 
 [Service]
 Type=simple
@@ -15,6 +16,8 @@ WorkingDirectory=<%= $workdir %>
 ExecStart=<%= $cmd %>
 Restart=on-failure
 RestartSec=42s
+StartLimitInterval=600
+StartLimitBurst=5
 User=<%= $user %>
 Group=<%= $group %>
 

--- a/templates/service/status-email-user@.service.epp
+++ b/templates/service/status-email-user@.service.epp
@@ -1,0 +1,8 @@
+<%- | String $envfile | -%>
+[Unit]
+Description=status email for %i
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/libexec/systemd-email $EMAIL %i
+EnvironmentFile=<%= $envfile %>

--- a/templates/service/systemd-email.epp
+++ b/templates/service/systemd-email.epp
@@ -1,0 +1,3 @@
+<%- | String $email | -%>
+# This file is managed by Puppet; changes may be overwritten.
+EMAIL=<%= $email %>


### PR DESCRIPTION
Also, set StartLimitInterval and StartLimitBurst,
to prevent endless restarts attempts.