### PR TITLE
Switch to using python3 to run the install.py script

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -182,7 +182,7 @@ Data type: `String`
 
 `install.py` git repo ref.
 
-Default value: `'IT-2233/working'`
+Default value: `'IT-4348/python3'`
 
 ##### <a name="-ccs_software--env"></a>`env`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,7 @@ class ccs_software (
   String                      $service_email           = 'root@localhost',
   Stdlib::HTTPUrl             $pkglist_repo_url        = 'https://github.com/lsst-camera-dh/dev-package-lists',
   Stdlib::HTTPUrl             $release_repo_url        = 'https://github.com/lsst-it/release',
-  String                      $release_repo_ref        = 'IT-2233/working',
+  String                      $release_repo_ref        = 'IT-4348/python3',
   Optional[String]            $env                     = undef,
   Optional[String]            $hostname                = $facts['networking']['hostname'],
   Boolean                     $desktop                 = false,

--- a/manifests/pre.pp
+++ b/manifests/pre.pp
@@ -9,6 +9,7 @@ class ccs_software::pre {
   $deps = [
     'unzip',
     'git',
+    'python3',
   ]
 
   ensure_packages($deps)

--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -8,22 +8,6 @@ describe 'ccs_software class' do
       <<-PP
       accounts::user { 'ccs': }
       accounts::user { 'ccsadm': }
-
-      if versioncmp($facts['os']['release']['major'],'8') >= 0 {
-        package { 'python3': }
-        -> alternatives { 'python':
-          path => '/usr/bin/python3',
-        }
-      }
-      if versioncmp($facts['os']['release']['major'],'9') >= 0 {
-        alternative_entry {'/usr/bin/python3':
-          ensure   => present,
-          altlink  => '/usr/bin/python',
-          altname  => 'python',
-          priority => 30,
-        }
-        -> Alternatives['python']
-      }
       PP
     end
 


### PR DESCRIPTION
python3 is available in the base OS since RHEL 7.7, and the script already runs fine (for CCS) with python3.
This removes the need to make a "python" alternative link.