### PR TITLE
Extend the service hash to allow for more options

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -90,7 +90,9 @@ Options:
 
 * **name-of-alias** `String`: [Array] of service names/service executables (links under /opt/lsst/<alias>/bin/)
 Alternatively, array element can also be a hash of the form
-{ name: "h2db, cmd: "/foo/bar/baz" }
+{ name: "h2db", key: "value", ... }
+Allowed keys: cmd, user, group, workdir.
+Values specify the associated service file values.
 
 Default value: `{}`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -90,7 +90,7 @@ Options:
 
 * **name-of-alias** `String`: [Array] of service names/service executables (links under /opt/lsst/<alias>/bin/)
 Alternatively, array element can also be a hash of the form
-{ name: "h2db", key: "value", ... }
+{ name: "h2db, key: "value", ... }
 Allowed keys: cmd, user, group, workdir, env.
 Values specify the associated service file values.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -90,7 +90,7 @@ Options:
 
 * **name-of-alias** `String`: [Array] of service names/service executables (links under /opt/lsst/<alias>/bin/)
 Alternatively, array element can also be a hash of the form
-{ name: "h2db, key: "value", ... }
+{ name: "h2db", key: "value", ... }
 Allowed keys: cmd, user, group, workdir, env.
 Values specify the associated service file values.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -91,7 +91,7 @@ Options:
 * **name-of-alias** `String`: [Array] of service names/service executables (links under /opt/lsst/<alias>/bin/)
 Alternatively, array element can also be a hash of the form
 { name: "h2db", key: "value", ... }
-Allowed keys: cmd, user, group, workdir.
+Allowed keys: cmd, user, group, workdir, env.
 Values specify the associated service file values.
 
 Default value: `{}`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@
 # @option services [String] name-of-alias
 #   [Array] of service names/service executables (links under /opt/lsst/<alias>/bin/)
 #   Alternatively, array element can also be a hash of the form
-#   { name: "h2db, key: "value", ... }
+#   { name: "h2db", key: "value", ... }
 #   Allowed keys: cmd, user, group, workdir, env.
 #   Values specify the associated service file values.
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,9 @@
 # @option services [String] name-of-alias
 #   [Array] of service names/service executables (links under /opt/lsst/<alias>/bin/)
 #   Alternatively, array element can also be a hash of the form
-#   { name: "h2db, cmd: "/foo/bar/baz" }
+#   { name: "h2db, key: "value", ... }
+#   Allowed keys: cmd, user, group, workdir, env.
+#   Values specify the associated service file values.
 #
 # @param base_path
 #   Base path for [all] CCS installations.

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,6 +15,7 @@ class ccs_software::service {
         $hash_user = $svc['user']
         $hash_group = $svc['group']
         $hash_workdir = $svc['workdir']
+        $service_env = $svc['env']
       } else {
         $service_name = $svc
         $cmd_base = $svc
@@ -30,6 +31,7 @@ class ccs_software::service {
         group   => $service_group,
         cmd     => $service_cmd,
         workdir => $service_workdir,
+        env     => $service_env,
       }
 
       systemd::unit_file { "${service_name}.service":

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -23,6 +23,7 @@ class ccs_software::service {
         $hash_user = ''
         $hash_group = ''
         $hash_workdir = ''
+        $service_env = undef
       }
       $cmd = "${ccs_software::ccs_path}/${alias}/bin/${cmd_base}"
       $service_cmd = pick($hash_cmd,$cmd)

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -19,6 +19,10 @@ class ccs_software::service {
       } else {
         $service_name = $svc
         $cmd_base = $svc
+        $hash_cmd = ''
+        $hash_user = ''
+        $hash_group = ''
+        $hash_workdir = ''
       }
       $cmd = "${ccs_software::ccs_path}/${alias}/bin/${cmd_base}"
       $service_cmd = pick($hash_cmd,$cmd)

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -22,9 +22,8 @@ describe 'ccs_software' do
             },
             services: {
               dev: ['comcam-mcm',
-                    { name: "comcam-ih",
-                      user: "ccs-ipa",
-                    }],
+                    { name: 'comcam-ih',
+                      user: 'ccs-ipa', }],
             },
           }
         end
@@ -52,7 +51,7 @@ describe 'ccs_software' do
             ).that_comes_before("Service[#{svc}]")
           end
         end
-        
+
         context 'with workdir parameter' do
           let(:params) do
             super().merge(service_workdir: '/foo/bar')

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -21,14 +21,17 @@ describe 'ccs_software' do
               },
             },
             services: {
-              dev: ['comcam-mcm'],
+              dev: ['comcam-mcm',
+                    { name: "comcam-ih",
+                      user: "ccs-ipa",
+                    }],
             },
           }
         end
 
         it { is_expected.to compile.with_all_deps }
 
-        ['comcam-mcm'].each do |svc|
+        ['comcam-mcm', 'comcam-ih'].each do |svc|
           it do
             is_expected.to contain_systemd__unit_file("#{svc}.service").with(
               content: %r{WorkingDirectory=/home/ccs}
@@ -42,6 +45,14 @@ describe 'ccs_software' do
           end
         end
 
+        ['comcam-ih'].each do |svc|
+          it do
+            is_expected.to contain_systemd__unit_file("#{svc}.service").with(
+              content: %r{User=ccs-ipa}
+            ).that_comes_before("Service[#{svc}]")
+          end
+        end
+        
         context 'with workdir parameter' do
           let(:params) do
             super().merge(service_workdir: '/foo/bar')

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -30,7 +30,7 @@ describe 'ccs_software' do
 
         it { is_expected.to compile.with_all_deps }
 
-        ['comcam-mcm', 'comcam-ih'].each do |svc|
+        %w[comcam-mcm comcam-ih].each do |svc|
           it do
             is_expected.to contain_systemd__unit_file("#{svc}.service").with(
               content: %r{WorkingDirectory=/home/ccs}

--- a/spec/support/acceptance/setup.rb
+++ b/spec/support/acceptance/setup.rb
@@ -1,23 +1,11 @@
 # frozen_string_literal: true
 
 configure_beaker do |host|
-  install_package(host, 'git')
   install_module_from_forge_on(host, 'puppetlabs/accounts', '> 7 < 8')
   install_module_from_forge_on(host, 'puppet/alternatives', '>= 4.1.0')
+  install_module_from_forge_on(host, 'lsst/java_artisanal', '>= 2.4.0 < 3')
   scp_to(host, "#{__dir__}/../../fixtures/facts/site.yaml", '/opt/puppetlabs/facter/facts.d/site.yaml')
   # XXX this is a kludge!  We need to overwrite the first automatic
   # installation of the dev module as the `log` dir is being filtered out.
   install_module(ignore_list: ['.bundle', 'bundle', '.vendor', 'vendor'])
-  clone_git_repo_on(host, '/etc/puppetlabs/code/environments/production/modules',
-                    name: 'java_artisanal',
-                    path: 'https://github.com/lsst-it/puppet-java_artisanal',
-                    rev: 'master')
-  # java_artisanal deps
-  {
-    'puppetlabs/accounts' => '> 1',
-    'puppet/yum' => '>= 4 < 6',
-    'puppet/alternatives' => '> 3 < 5',
-  }.each do |mod, rev|
-    install_module_from_forge_on(host, mod, rev)
-  end
 end

--- a/templates/service/ccs.service.epp
+++ b/templates/service/ccs.service.epp
@@ -2,7 +2,8 @@
       String $user,
       String $group,
       String $cmd,
-      String $workdir
+      String $workdir,
+      Optional[String] $env = undef
 | -%>
 [Unit]
 Description=<%= $desc %>
@@ -13,6 +14,9 @@ OnFailure=status-email-user@%n.service
 [Service]
 Type=simple
 WorkingDirectory=<%= $workdir %>
+<% unless $env =~ Undef { -%>
+Environment=<%= $env %>
+<% } -%>
 ExecStart=<%= $cmd %>
 Restart=on-failure
 RestartSec=42s


### PR DESCRIPTION
This allows to run service as different users or groups, with different working directories or environments.
Needed for item 3 in https://jira.lsstcorp.org/browse/IT-4438

I tried to add some acceptance tests, but am not confident I got it right (spec tests don't seem to get run for this repo).
(I've verified by experiment that the change works.)
