### PR TITLE
Add wget as a required system package

### DIFF
--- a/manifests/pre.pp
+++ b/manifests/pre.pp
@@ -10,6 +10,7 @@ class ccs_software::pre {
     'unzip',
     'git',
     'python3',
+    'wget',
   ]
 
   ensure_packages($deps)

--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -93,7 +93,7 @@ describe 'ccs_software class' do
     end
 
     # package deps
-    %w[unzip git].each do |p|
+    %w[unzip git wget].each do |p|
       describe package(p) do
         it { is_expected.to be_installed }
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -90,6 +90,7 @@ describe 'ccs_software' do
         it do
           is_expected.to contain_package('unzip')
           is_expected.to contain_package('git')
+          is_expected.to contain_package('wget')
         end
       end
 


### PR DESCRIPTION
Add ~curl and~ wget as explicitly required system packages. They are used internally by the CCS install script. At least with RHEL8, it is otherwise possible to install a system without wget, leading the CCS install script to abort partway through.
