### PR TITLE
Bump version to 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v2.2.1](https://github.com/lsst-it/puppet-ccs_software/tree/v2.2.1) (2024-03-18)
+
+[Full Changelog](https://github.com/lsst-it/puppet-ccs_software/compare/v2.2.0...v2.2.1)
+
+**Implemented enhancements:**
+
+- Add wget as a required system package [\#52](https://github.com/lsst-it/puppet-ccs_software/pull/52) ([glennmorris](https://github.com/glennmorris))
+
 ## [v2.2.0](https://github.com/lsst-it/puppet-ccs_software/tree/v2.2.0) (2023-10-04)
 
 [Full Changelog](https://github.com/lsst-it/puppet-ccs_software/compare/v2.1.0...v2.2.0)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "lsst-ccs_software",
-  "version": "2.2.1-rc0",
+  "version": "2.2.1",
   "author": "AURA/LSST",
   "summary": "Configure CCS Software",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is needed to deploy the trivial rhel8+ changes from some time ago.
