### PR TITLE
rm acceptance test usage of puppetlabs/accounts mod

### DIFF
--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -6,8 +6,10 @@ describe 'ccs_software class' do
   describe 'prepare host' do
     let(:manifest) do
       <<-PP
-      accounts::user { 'ccs': }
-      accounts::user { 'ccsadm': }
+      user { ['ccs', 'ccsadm']:
+        ensure     => 'present',
+        managehome => true,
+      }
       PP
     end
 

--- a/spec/support/acceptance/setup.rb
+++ b/spec/support/acceptance/setup.rb
@@ -3,6 +3,5 @@
 configure_beaker(modules: :metadata) do |host|
   scp_to(host, "#{__dir__}/../../fixtures/facts/site.yaml", '/opt/puppetlabs/facter/facts.d/site.yaml')
   install_puppet_module_via_pmt_on(host, 'puppet/alternatives', '5')
-  install_puppet_module_via_pmt_on(host, 'puppetlabs/accounts', '8')
   install_puppet_module_via_pmt_on(host, 'puppetlabs/java', '10')
 end


### PR DESCRIPTION
because the accpetance tests are failing under puppet8 because of this bug: https://github.com/puppetlabs/puppetlabs-accounts/pull/476