### PR TITLE
use stdlib::ensure_packages() and require stdlib >= 9

### DIFF
--- a/manifests/pre.pp
+++ b/manifests/pre.pp
@@ -13,5 +13,5 @@ class ccs_software::pre {
     'wget',
   ]
 
-  ensure_packages($deps)
+  stdlib::ensure_packages($deps)
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 5.0.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/vcsrepo",


### PR DESCRIPTION
Resolves this warning:

    Warning: This function is deprecated, please use stdlib::ensure_packages instead. at ["/etc/puppetlabs/code/environments/production/modules/ccs_software/manifests/pre.pp", 16]:["/etc/puppetlabs/code/environments/production/modules/ccs_software/manifests/init.pp", 119]