### PR TITLE
(tomcat) add the option to install ccs tomcat configuration

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -18,6 +18,7 @@
 * `ccs_software::log`: Create /var/log/ccs and install logrotation.
 * `ccs_software::pre`: Install ccs software prerequisites
 * `ccs_software::service`: Manages ccs systemd service units
+* `ccs_software::tomcat`: Install /etc/ccs/tomcat files.
 
 ## Classes
 
@@ -35,6 +36,7 @@ The following parameters are available in the `ccs_software` class:
 * [`base_path`](#-ccs_software--base_path)
 * [`etc_path`](#-ccs_software--etc_path)
 * [`log_path`](#-ccs_software--log_path)
+* [`tomcat_rest_etc_path`](#-ccs_software--tomcat_rest_etc_path)
 * [`user`](#-ccs_software--user)
 * [`group`](#-ccs_software--group)
 * [`adm_user`](#-ccs_software--adm_user)
@@ -47,8 +49,12 @@ The following parameters are available in the `ccs_software` class:
 * [`hostname`](#-ccs_software--hostname)
 * [`desktop`](#-ccs_software--desktop)
 * [`git_force`](#-ccs_software--git_force)
+* [`tomcat_rest`](#-ccs_software--tomcat_rest)
 * [`global_properties`](#-ccs_software--global_properties)
 * [`udp_properties`](#-ccs_software--udp_properties)
+* [`tomcat_rest_url`](#-ccs_software--tomcat_rest_url)
+* [`tomcat_rest_user`](#-ccs_software--tomcat_rest_user)
+* [`tomcat_rest_pass`](#-ccs_software--tomcat_rest_pass)
 
 ##### <a name="-ccs_software--installations"></a>`installations`
 
@@ -119,6 +125,14 @@ Data type: `Stdlib::Absolutepath`
 Path to CCS log files.
 
 Default value: `'/var/log/ccs'`
+
+##### <a name="-ccs_software--tomcat_rest_etc_path"></a>`tomcat_rest_etc_path`
+
+Data type: `Stdlib::Absolutepath`
+
+Path to CCS tomcat configuration directory.
+
+Default value: `'/etc/ccs/tomcat'`
 
 ##### <a name="-ccs_software--user"></a>`user`
 
@@ -220,6 +234,14 @@ true` to `vcsrepo` type resources.
 
 Default value: `false`
 
+##### <a name="-ccs_software--tomcat_rest"></a>`tomcat_rest`
+
+Data type: `Boolean`
+
+If true, install tomcat rest server configuration
+
+Default value: `false`
+
 ##### <a name="-ccs_software--global_properties"></a>`global_properties`
 
 Data type: `Array[String]`
@@ -235,4 +257,28 @@ Data type: `Array[String]`
 Array of extra strings to add to the udp_ccs.properties file.
 
 Default value: `[]`
+
+##### <a name="-ccs_software--tomcat_rest_url"></a>`tomcat_rest_url`
+
+Data type: `String[1]`
+
+String giving URL for the rest server.
+
+Default value: `'lsstcam-db01:3306/ccsdbprod'`
+
+##### <a name="-ccs_software--tomcat_rest_user"></a>`tomcat_rest_user`
+
+Data type: `Sensitive[String[1]]`
+
+Sensitive string giving username for the rest server.
+
+Default value: `Sensitive('user')`
+
+##### <a name="-ccs_software--tomcat_rest_pass"></a>`tomcat_rest_pass`
+
+Data type: `Sensitive[String[1]]`
+
+Sensitive string giving password for the rest server.
+
+Default value: `Sensitive('pass')`
 

--- a/manifests/tomcat.pp
+++ b/manifests/tomcat.pp
@@ -1,0 +1,44 @@
+#
+# @summary
+#   Install /etc/ccs/tomcat files.
+#
+# @api private
+class ccs_software::tomcat {
+  assert_private()
+
+  $etc_path = $ccs_software::tomcat_rest_etc_path
+  $etc_user = 'tomcat'
+  $etc_group = $ccs_software::adm_group
+  $user = $ccs_software::tomcat_rest_user
+  $pass = $ccs_software::tomcat_rest_pass
+  $url = $ccs_software::tomcat_rest_url
+
+  ensure_resources('file', {
+      $etc_path => {
+        ensure => directory,
+        owner  => $etc_user,
+        group  => $etc_group,
+        mode   => '2770',
+      },
+  })
+
+  ## Hash of templates and any arguments they take.
+  $etc_files = {
+    'logging.properties' => {},
+    'statusPersister.properties' => {
+      'user' => $user,
+      'pass' => $pass,
+      'url'  => $url,
+    },
+  }
+
+  $etc_files.each |$file, $epp_vars| {
+    file { "${etc_path}/${file}":
+      ensure  => file,
+      owner   => $etc_user,
+      group   => $etc_group,
+      mode    => '0660',
+      content => epp("${module_name}/tomcat/${file}.epp", $epp_vars),
+    }
+  }
+}

--- a/templates/tomcat/logging.properties.epp
+++ b/templates/tomcat/logging.properties.epp
@@ -1,0 +1,74 @@
+# This file is managed by Puppet; changes may be overwritten
+
+# Properties file which configures the operation of the CCS
+# logging facility.
+
+# Global logging properties.
+# ------------------------------------------
+# The set of handlers to be loaded upon startup.
+# Comma-separated list of class names.
+# (? LogManager docs say no comma here, but JDK example has comma.)
+# do not put space characters in this list!
+# handlers are loaded by the primordial log manager
+
+handlers=org.lsst.ccs.utilities.logging.DailyRollingFileHandler,java.util.logging.ConsoleHandler
+
+## BEWARE: you CAN'T set  org.lsst.ccs.bus.utils.LogBusHandler HERE!
+## because it is initialized later (when the buses are activated)
+
+# Default global logging level.
+# Loggers and Handlers may override this level
+# SEE LSSTCCS-290
+.level=WARNING
+
+#The level of the CCS Root logger LSSTCCS-297
+org.lsst.ccs.level=INFO
+# Loggers
+# ------------------------------------------
+# Loggers are usually attached to packages.
+# Here, the level for each package is specified.
+# The global level is used by default, so levels
+# specified here simply act as an override.
+#myapp.ui.level=ALL
+#myapp.business.level=CONFIG
+#myapp.data.level=SEVERE
+
+
+# Handlers
+# -----------------------------------------
+
+# --- ConsoleHandler ---
+# Override of global logging level
+java.util.logging.ConsoleHandler.level=INFO
+
+
+## Pattern and Level
+org.lsst.ccs.utilities.logging.DailyRollingFileHandler.pattern=/var/log/ccs/ccs-rest-server.log
+org.lsst.ccs.utilities.logging.DailyRollingFileHandler.level=ALL
+
+## Number of log files to cycle through restarts
+org.lsst.ccs.utilities.logging.DailyRollingFileHandler.count=100
+
+# Style of output
+org.lsst.ccs.utilities.logging.DailyRollingFileHandler.formatter=java.util.logging.SimpleFormatter
+
+
+# a special formatter that deals with StackTraces
+org.lsst.ccs.messaging.LogBusHandler.formatter=org.lsst.ccs.utilities.logging.TextFormatter
+java.util.logging.ConsoleHandler.formatter=org.lsst.ccs.utilities.logging.TextFormatter
+
+# change that one if you want to modify the way StackTraces are printed
+# negative value means all the stacktrace will be printed
+org.lsst.ccs.logging.StackTraceFormats.depth=2
+
+# Example to customize the SimpleFormatter output format
+# to print one-line log message like this:
+#     <level>: <log message> [<date/time>]
+#
+java.util.logging.SimpleFormatter.format=[%1$tY-%1$tm-%1$tdT%1$tT.%1$tL%1$tZ] %4$s: %5$s (%2$s)%n%6$s
+
+# index starts at 1 : date, source, Logger, Level, message, throwableStr
+# here we have <source> :<log message> <throwable>
+org.lsst.ccs.utilities.logging.TextFormatter.format=%4$s: %5$s (%2$s) [%1$tc]%n%6$s
+
+org.lsst.ccs.localdb.level=INFO

--- a/templates/tomcat/statusPersister.properties.epp
+++ b/templates/tomcat/statusPersister.properties.epp
@@ -1,0 +1,11 @@
+<%- | Sensitive[String[1]] $user,
+      Sensitive[String[1]] $pass,
+      String[1] $url
+| -%>
+# This file is managed by Puppet; changes may be overwritten
+hibernate.connection.url=jdbc:mysql://<%= $url %>
+hibernate.connection.driver_class=com.mysql.jdbc.Driver
+#hibernate.dialect=org.hibernate.dialect.MySQLDialect
+hibernate.dialect=org.hibernate.dialect.MariaDBDialect
+hibernate.connection.username=<%= $user %>
+hibernate.connection.password=<%= $pass %>


### PR DESCRIPTION
I put this in here rather than in profile::ccs::tomcat because it relies on some of the machinery and parameters from this module, and conceptually it relates to (part of) what this module does (set up /etc/ccs).
