### PR TITLE
(files/install/installCCS.sh) update CCS install script for use on summit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,25 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
-## [v2.2.1](https://github.com/lsst-it/puppet-ccs_software/tree/v2.2.1) (2024-03-18)
+## [v2.2.2](https://github.com/lsst-it/puppet-ccs_software/tree/v2.2.2) (2024-05-20)
 
-[Full Changelog](https://github.com/lsst-it/puppet-ccs_software/compare/v2.2.0...v2.2.1)
+[Full Changelog](https://github.com/lsst-it/puppet-ccs_software/compare/v2.2.1...v2.2.2)
 
 **Implemented enhancements:**
 
+- \(puppet-ccs-software\) add license file [\#56](https://github.com/lsst-it/puppet-ccs_software/pull/56) ([dtapiacl](https://github.com/dtapiacl))
+
+## [v2.2.1](https://github.com/lsst-it/puppet-ccs_software/tree/v2.2.1) (2024-03-19)
+
+[Full Changelog](https://github.com/lsst-it/puppet-ccs_software/compare/v2.2.0...v2.2.1)
+
+**Breaking changes:**
+
+- use stdlib::ensure\_packages\(\) and require stdlib \>= 9 [\#55](https://github.com/lsst-it/puppet-ccs_software/pull/55) ([jhoblitt](https://github.com/jhoblitt))
+
+**Implemented enhancements:**
+
+- Bump version to 2.2.1 [\#53](https://github.com/lsst-it/puppet-ccs_software/pull/53) ([glennmorris](https://github.com/glennmorris))
 - Add wget as a required system package [\#52](https://github.com/lsst-it/puppet-ccs_software/pull/52) ([glennmorris](https://github.com/glennmorris))
 
 ## [v2.2.0](https://github.com/lsst-it/puppet-ccs_software/tree/v2.2.0) (2023-10-04)

--- a/files/install/installCCS.sh
+++ b/files/install/installCCS.sh
@@ -6,11 +6,12 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-ENVIRONMENT=$1
-NODE_NAME=$2
+TAG=$1
+ENVIRONMENT=$2
+NODE_NAME=$3
 
 BASEDIR=$(dirname "$0")
-DEV_PACKAGE_DIR="/lsst/ccsadm/dev-package-lists"
+DEV_PACKAGE_DIR="/home/ccs/dev-package-lists"
 RELEASE_INSTALL_SCRIPT="/lsst/ccsadm/release/bin/install.py"
 CCS_INSTALL_DIR="/lsst/ccs/"$(date +%Y%m%d)
 
@@ -28,13 +29,21 @@ then
 
     # Check that the dev-package-lists github project is up to date.
     # If not abort.
+    if [ ! -d $DEV_PACKAGE_DIR ]; then
+	git clone https://github.com/lsst-camera-dh/dev-package-lists.git $DEV_PACKAGE_DIR
+    fi
     cd $DEV_PACKAGE_DIR || exit
+    if ! git checkout "$TAG"; then
+	echo "Tag $TAG does not exist"
+	exit
+    fi
+
     if ! gitPull=$(git pull); then
 	echo "Something went wrong when updating $DEV_PACKAGE_DIR: $?: $gitPull"
 	exit
     fi
     gitStatus=$(git status)
-    if [[ $gitStatus != *"nothing to commit, working directory clean"* ]]; then
+    if [[ $gitStatus != *"nothing to commit, working tree clean"* ]]; then
 	echo Directory $DEV_PACKAGE_DIR is not up to date. Exiting.
 	exit
     fi

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "lsst-ccs_software",
-  "version": "2.2.2-rc0",
+  "version": "2.2.2",
   "author": "AURA/LSST",
   "summary": "Configure CCS Software",
   "license": "Apache-2.0",


### PR DESCRIPTION
The installCCS.sh script is not used by puppet, only when doing manual CCS installs (for testing etc).
Now it takes a branch as argument.
Also, it makes more sense for /lsst/ccsadm/dev-package-lists (not created or managed by puppet) to move to /home/ccs.