### PR TITLE
Allow control over the enable state of services

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -91,8 +91,8 @@ Options:
 * **name-of-alias** `String`: [Array] of service names/service executables (links under /opt/lsst/<alias>/bin/)
 Alternatively, array element can also be a hash of the form
 { name: "h2db", key: "value", ... }
-Allowed keys: cmd, user, group, workdir, env.
-Values specify the associated service file values.
+Allowed keys: cmd, user, group, workdir, env, enable.
+Values specify the associated service file values/state.
 
 Default value: `{}`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,8 +28,8 @@
 #   [Array] of service names/service executables (links under /opt/lsst/<alias>/bin/)
 #   Alternatively, array element can also be a hash of the form
 #   { name: "h2db", key: "value", ... }
-#   Allowed keys: cmd, user, group, workdir, env.
-#   Values specify the associated service file values.
+#   Allowed keys: cmd, user, group, workdir, env, enable.
+#   Values specify the associated service file values/state.
 #
 # @param base_path
 #   Base path for [all] CCS installations.

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,6 +16,7 @@ class ccs_software::service {
         $hash_group = $svc['group']
         $hash_workdir = $svc['workdir']
         $service_env = $svc['env']
+        $hash_enable = $svc['enable']
       } else {
         $service_name = $svc
         $cmd_base = $svc
@@ -24,12 +25,14 @@ class ccs_software::service {
         $hash_group = ''
         $hash_workdir = ''
         $service_env = undef
+        $hash_enable = undef
       }
       $cmd = "${ccs_software::ccs_path}/${alias}/bin/${cmd_base}"
       $service_cmd = pick($hash_cmd,$cmd)
       $service_user = pick($hash_user,$ccs_software::user)
       $service_group = pick($hash_group,$ccs_software::group)
       $service_workdir = pick($hash_workdir,$ccs_software::_real_service_workdir)
+      $service_enable = pick($hash_enable,true)
       $epp_vars = {
         desc    => "CCS ${service_name} service",
         user    => $service_user,
@@ -43,7 +46,7 @@ class ccs_software::service {
         content => epp("${module_name}/service/ccs.service.epp", $epp_vars),
       }
       -> service { $service_name:
-        enable => true,
+        enable => $service_enable,
       }
 
       ## NB this uses $ccs_software::user even if the service runs

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -22,6 +22,8 @@ describe 'ccs_software' do
             },
             services: {
               dev: ['comcam-mcm',
+                    { name: 'comcam-disabled',
+                      enable: false, },
                     { name: 'comcam-ih',
                       user: 'ccs-ipa', }],
             },
@@ -49,6 +51,14 @@ describe 'ccs_software' do
             is_expected.to contain_systemd__unit_file("#{svc}.service").with(
               content: %r{User=ccs-ipa}
             ).that_comes_before("Service[#{svc}]")
+          end
+        end
+
+        ['comcam-disabled'].each do |svc|
+          it do
+            is_expected.to contain_service(svc).with(
+              enable: false
+            )
           end
         end
 


### PR DESCRIPTION
This is for services that people want to have defined but disabled, so they can start them manually, eg for testing.