### PR TITLE
(install) increase timeout on install.py command

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -176,7 +176,7 @@ class ccs_software::install {
       tries     => 3,
       logoutput => true,
       cwd       => $base_path,
-      timeout   => 900,
+      timeout   => 1800,
     }
     ~> exec { $exec_chown_title:
       command   => "${pre_script} chown -R -H ${user}:${group} \${PDIR}",


### PR DESCRIPTION
In case of slow downloads from nexus. Ref
https://rubinobs.atlassian.net/browse/IT-6890