### PR TITLE
(metadata) drop puppet 7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ]
 }


### PR DESCRIPTION
Tests have been failing for some time on puppet 7, time to drop support.